### PR TITLE
Post tables into separate threads of events

### DIFF
--- a/src/jvmMain/kotlin/org/codecranachan/roster/bot/BotMessage.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/bot/BotMessage.kt
@@ -2,22 +2,26 @@ package org.codecranachan.roster.bot
 
 import discord4j.common.util.Snowflake
 import discord4j.core.`object`.entity.Message
+import org.codecranachan.roster.core.Event
+import org.codecranachan.roster.core.Player
 import org.codecranachan.roster.util.Quotes
 import org.codecranachan.roster.util.orNull
 
 data class BotMessage(val authorId: Snowflake, val title: String, val text: String = Quotes.getRandom()) {
 
-    fun hasSameAuthor(msg: Message): Boolean {
-        return msg.author.orNull()?.id == authorId
-    }
+    companion object {
+        private val titleRegex = Regex("^[*]{2}(?<title>[^\n*]+)[*]{2}\n(?<body>.*)$", RegexOption.DOT_MATCHES_ALL)
 
-    fun hasSameTitle(msg: Message): Boolean {
-        return msg.content.startsWith(formattedTitle)
+        fun getMessageTitle(msg: Message) = getTitleFromText(msg.content)
+        fun getTitleFromText(text: String) = titleRegex.matchEntire(text)?.let { it.groups["title"]?.value }
+
+        fun getTableTitle(event: Event, dm: Player): String = "${dm.getTableName()} - ${event.getChannelName()}"
     }
 
     fun asContent(): String {
         return listOf(formattedTitle, text).joinToString("\n")
     }
 
-    private val formattedTitle : String = "**$title**"
+
+    private val formattedTitle: String = "**$title**"
 }

--- a/src/jvmMain/kotlin/org/codecranachan/roster/bot/CoreExtensions.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/bot/CoreExtensions.kt
@@ -2,7 +2,7 @@ package org.codecranachan.roster.bot
 
 import kotlinx.datetime.toJavaLocalDate
 import org.codecranachan.roster.core.Event
-import org.codecranachan.roster.query.EventQueryResult
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.SignStyle
@@ -23,4 +23,10 @@ fun Event.getChannelName(): String {
 
 fun Event.getChannelTopic(): String {
     return "Role playing event on ${formattedDate} posted on Crawl Roster"
+}
+
+fun String.parseAsEventDate(): LocalDate? {
+    return runCatching {
+        EVENT_DATE_FORMATTER.parse(this, LocalDate::from)
+    }.getOrElse { null }
 }

--- a/src/jvmMain/kotlin/org/codecranachan/roster/bot/EntityCache.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/bot/EntityCache.kt
@@ -1,0 +1,42 @@
+package org.codecranachan.roster.bot
+
+import discord4j.common.util.Snowflake
+import discord4j.core.`object`.entity.Entity
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+
+class EntityCache {
+    data class Key(
+        val type: Class<*>,
+        val name: String
+    )
+
+    val entityCache: ConcurrentHashMap<Key, CompletableFuture<out Entity>> = ConcurrentHashMap()
+    private val removeActions: ConcurrentHashMap<Snowflake, Runnable> = ConcurrentHashMap()
+
+    inline fun <reified T : Entity> get(
+        name: String,
+        factory: (String) -> CompletableFuture<T>
+    ): CompletableFuture<T> {
+        val key = Key(T::class.java, name)
+        return entityCache.getOrPut(key) {
+            factory.invoke(name).withRemoveAction(key)
+        }.thenApply {
+            T::class.java.cast(it)
+        }
+    }
+
+    fun put(name: String, entity: Entity) {
+        val key = Key(entity.javaClass, name)
+        entityCache[key] = CompletableFuture.completedFuture(entity).withRemoveAction(key)
+    }
+
+    fun <T : Entity> CompletableFuture<T>.withRemoveAction(key: Key): CompletableFuture<T> {
+        thenAccept { removeActions[it.id] = Runnable { entityCache.remove(key) } }
+        return this
+    }
+
+    fun remove(id: Snowflake) {
+        removeActions.remove(id)?.run()
+    }
+}

--- a/src/jvmMain/kotlin/org/codecranachan/roster/bot/RosterBot.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/bot/RosterBot.kt
@@ -65,7 +65,7 @@ class RosterBot(val core: RosterCore, botToken: String, rootUrl: String) {
     private val client: DiscordClient = botToken.let(DiscordClient::create)
     private val disposables = ArrayList<Disposable>()
 
-    private val tracking = GuildTracking()
+    private val tracking = DiscordTracking()
 
     private val templates = MessageTemplates(rootUrl)
 
@@ -282,7 +282,7 @@ class RosterBot(val core: RosterCore, botToken: String, rootUrl: String) {
                         )
                     )
 
-                val botMessage = BotMessage(botId, data.getTableName(), content)
+                val botMessage = BotMessage(botId, BotMessage.getTableTitle(data.event, data.dm), content)
 
                 msg.edit()
                     .withContentOrNull(botMessage.asContent().take(2000))
@@ -298,7 +298,7 @@ class RosterBot(val core: RosterCore, botToken: String, rootUrl: String) {
         tracking.get(event.guildId)?.apply {
             withTableMessage(event, dm) { msg ->
                 val content = templates.closedTableMessageContent(dm)
-                val botMessage = BotMessage(botId, dm.getTableName(), content)
+                val botMessage = BotMessage(botId, BotMessage.getTableTitle(event, dm), content)
                 msg.edit()
                     .withContentOrNull(botMessage.asContent().take(2000))
                     .withComponents()

--- a/src/jvmMain/resources/themes/event.cmsg
+++ b/src/jvmMain/resources/themes/event.cmsg
@@ -6,7 +6,7 @@ To register you can use the buttons on this message or head over to {$root_url}.
 
 -- Table lineup ---
 {% loop in $tables as $tbl %}
-- {$tbl.dungeon_master.discord_mention} is hosting **{$tbl.table.details.adventure_title}** ({$tbl.occupancy_fraction} players)
+- {$tbl.dungeon_master.discord_mention} is hosting **{$tbl.table.details.adventure_title:Mystery Adventure}** ({$tbl.occupancy_fraction} players)
 {% onEmpty %}
 No dungeon masters have signed up
 {% endloop %}

--- a/src/jvmTest/kotlin/org/codecranachan/roster/bot/BotMessageTest.kt
+++ b/src/jvmTest/kotlin/org/codecranachan/roster/bot/BotMessageTest.kt
@@ -1,0 +1,27 @@
+package org.codecranachan.roster.bot
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+
+class BotMessageTest {
+
+    @Test
+    fun testTitleExtraction() {
+        val text =
+            """**04-10-2023**
+            The event on WED - 4. October, 2023 is now accepting registrations.
+            
+            Tables will be set at the usual place and doors will open at the usual time
+            To register you can use the buttons on this message or head over to http://localhost:8080.
+            
+            -- Table lineup ---
+            No dungeon masters have signed up
+            
+            --- We have **0** players attending and enough tables for **0** ---
+            **Unseated players**
+            All players are seated""".trimIndent()
+
+        assertThat(BotMessage.getTitleFromText(text)).isEqualTo("04-10-2023")
+    }
+}


### PR DESCRIPTION
Table messages now get posted into their own thread within the event channel.
The bot will clean out old Table messages (that are not in threads) at startup.
Massively improves the update speed of the Discord Bot.