### PR TITLE
Power to the Dms

### DIFF
--- a/src/jsMain/kotlin/components/EventLineup.kt
+++ b/src/jsMain/kotlin/components/EventLineup.kt
@@ -18,6 +18,8 @@ external interface EventLineupProps : Props {
 }
 
 val EventLineup = FC<EventLineupProps> { props ->
+    val isHosting = props.result.isHosting(props.me.id)
+
     TableContainer {
         Table {
             size = Size.small
@@ -33,6 +35,7 @@ val EventLineup = FC<EventLineupProps> { props ->
                         .forEach { reg ->
                             RegistrationRow {
                                 me = props.me
+                                meIsHosting = false
                                 registration = reg
                             }
                         }
@@ -45,6 +48,7 @@ val EventLineup = FC<EventLineupProps> { props ->
                     .forEach { reg ->
                         RegistrationRow {
                             me = props.me
+                            meIsHosting = isHosting
                             registration = reg
                         }
                     }

--- a/src/jsMain/kotlin/components/editors/TableEditor.kt
+++ b/src/jsMain/kotlin/components/editors/TableEditor.kt
@@ -49,10 +49,10 @@ val TableEditor = FC<Props> {
     val (description, setDescription) = useState("")
     val (designation, setDesignation) = useState("")
     val (language, setLanguage) = useState(TableLanguage.SwissGerman)
-    val (minPlayers, setMinPlayers) = useState(3)
-    val (maxPlayers, setMaxPlayers) = useState(7)
-    val (minLevel, setMinLevel) = useState(1)
-    val (maxLevel, setMaxLevel) = useState(4)
+    val (minPlayers, setMinPlayers) = useState("3")
+    val (maxPlayers, setMaxPlayers) = useState("7")
+    val (minLevel, setMinLevel) = useState("1")
+    val (maxLevel, setMaxLevel) = useState("4")
 
     fun updateTable(table: Table) {
         setEventId(table.eventId)
@@ -61,10 +61,10 @@ val TableEditor = FC<Props> {
         setDescription(table.details.adventureDescription ?: "")
         setDesignation(table.details.moduleDesignation ?: "")
         setLanguage(table.details.language)
-        setMinPlayers(table.details.playerRange.first)
-        setMaxPlayers(table.details.playerRange.last)
-        setMinLevel(table.details.levelRange.first)
-        setMaxLevel(table.details.levelRange.last)
+        setMinPlayers(table.details.playerRange.first.toString())
+        setMaxPlayers(table.details.playerRange.last.toString())
+        setMinLevel(table.details.levelRange.first.toString())
+        setMaxLevel(table.details.levelRange.last.toString())
     }
 
     useEffectOnce {
@@ -154,8 +154,7 @@ val TableEditor = FC<Props> {
                         type = InputType.number
                         onChange = {
                             val e = it.unsafeCast<ChangeEvent<HTMLInputElement>>()
-                            val v = toIntInRange(e.target.value, Boundaries.MIN_PLAYERS..maxPlayers)
-                            setMinPlayers(v)
+                            setMinPlayers(e.target.value)
                         }
                     }
                     TextField {
@@ -165,8 +164,7 @@ val TableEditor = FC<Props> {
                         type = InputType.number
                         onChange = {
                             val e = it.unsafeCast<ChangeEvent<HTMLInputElement>>()
-                            val v = toIntInRange(e.target.value, minPlayers..Boundaries.MAX_PLAYERS)
-                            setMaxPlayers(v)
+                            setMaxPlayers(e.target.value)
                         }
                     }
                 }
@@ -179,8 +177,7 @@ val TableEditor = FC<Props> {
                         type = InputType.number
                         onChange = {
                             val e = it.unsafeCast<ChangeEvent<HTMLInputElement>>()
-                            val v = toIntInRange(e.target.value, Boundaries.MIN_LEVEL..maxLevel)
-                            setMinLevel(v)
+                            setMinLevel(e.target.value)
                         }
                     }
                     TextField {
@@ -190,8 +187,7 @@ val TableEditor = FC<Props> {
                         type = InputType.number
                         onChange = {
                             val e = it.unsafeCast<ChangeEvent<HTMLInputElement>>()
-                            val v = toIntInRange(e.target.value, minLevel..Boundaries.MAX_LEVEL)
-                            setMaxLevel(v)
+                            setMaxLevel(e.target.value)
                         }
                     }
                 }
@@ -208,6 +204,11 @@ val TableEditor = FC<Props> {
             Button {
                 startIcon = Save.create()
                 onClick = { _ ->
+                    val truncatedMaxPlayers = toIntInRange(maxPlayers, Boundaries.MIN_PLAYERS..Boundaries.MAX_PLAYERS)
+                    val truncatedMinPlayers = toIntInRange(minPlayers, Boundaries.MIN_PLAYERS..truncatedMaxPlayers)
+                    val truncatedMaxLevel = toIntInRange(maxLevel, Boundaries.MIN_LEVEL..Boundaries.MAX_LEVEL)
+                    val truncatedMinLevel = toIntInRange(minLevel, Boundaries.MIN_LEVEL..truncatedMaxLevel)
+
                     store.dispatch(
                         updateTableDetails(
                             eventId!!,
@@ -217,8 +218,8 @@ val TableEditor = FC<Props> {
                                 description,
                                 designation,
                                 language,
-                                minPlayers..maxPlayers,
-                                minLevel..maxLevel
+                                truncatedMinPlayers..truncatedMaxPlayers,
+                                truncatedMinLevel..truncatedMaxLevel
                             )
                         )
                     )

--- a/src/jsMain/kotlin/components/events/RegistrationRow.kt
+++ b/src/jsMain/kotlin/components/events/RegistrationRow.kt
@@ -1,11 +1,17 @@
 package components.events
 
+import api.updatePlayerRegistration
 import csstype.Border
 import csstype.LineStyle
 import csstype.px
 import mui.icons.material.AccessAlarm
 import mui.icons.material.AccountCircle
+import mui.icons.material.ErrorOutline
 import mui.icons.material.Person
+import mui.material.Button
+import mui.material.ButtonGroup
+import mui.material.Chip
+import mui.material.Size
 import mui.material.SvgIconColor
 import mui.material.SvgIconSize
 import mui.material.TableCell
@@ -15,13 +21,22 @@ import org.codecranachan.roster.core.Player
 import org.codecranachan.roster.query.ResolvedRegistration
 import react.FC
 import react.Props
+import react.ReactNode
+import react.create
+import react.useContext
+import reducers.StoreContext
+import reducers.removeRegistration
+import reducers.updateRegistration
 
 external interface RegistrationRowProps : Props {
     var me: Player
+    var meIsHosting: Boolean
     var registration: ResolvedRegistration
 }
 
 val RegistrationRow = FC<RegistrationRowProps> { props ->
+    val myStore = useContext(StoreContext)
+
     TableRow {
         TableCell {
             if (props.me.id == props.registration.player.id)
@@ -39,6 +54,37 @@ val RegistrationRow = FC<RegistrationRowProps> { props ->
             +"$langs $tier"
         }
         TableCell {
+            ButtonGroup {
+                if (props.me.id == props.registration.dungeonMaster?.id) {
+                    Button {
+                        onClick = {
+                            myStore.dispatch(
+                                updateRegistration(
+                                    props.registration.registration.eventId,
+                                    props.registration.registration.playerId,
+                                    null
+                                )
+                            )
+                        }
+                        size = Size.small
+                        +"Kick"
+                    }
+                } else if (props.meIsHosting) {
+                    Button {
+                        onClick = {
+                            myStore.dispatch(
+                                updateRegistration(
+                                    props.registration.registration.eventId,
+                                    props.registration.registration.playerId,
+                                    props.me.id
+                                )
+                            )
+                        }
+                        size = Size.small
+                        +"Invite"
+                    }
+                }
+            }
         }
     }
 }

--- a/src/jsMain/kotlin/reducers/Thunks.kt
+++ b/src/jsMain/kotlin/reducers/Thunks.kt
@@ -74,6 +74,13 @@ fun updateRegistration(e: Event, t: Table?): Thunk<ApplicationState> = { dispatc
     }
 }
 
+fun updateRegistration(eventId: Uuid, playerId: Uuid, dmId: Uuid?): Thunk<ApplicationState> = { dispatch, getState, _ ->
+    scope.launch {
+            updatePlayerRegistration(eventId, playerId, dmId)
+            dispatch(updateEvents(getState().calendar.selectedLinkedGuild))
+    }
+}
+
 fun removeRegistration(e: Event): Thunk<ApplicationState> = { dispatch, getState, _ ->
     scope.launch {
         val account = getState().identity.player

--- a/src/jvmMain/kotlin/org/codecranachan/roster/api/EventApi.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/api/EventApi.kt
@@ -90,11 +90,16 @@ class EventApi(private val core: RosterCore) {
                     val evtId = Uuid.fromString(call.parameters["evtId"])
                     val plrId = Uuid.fromString(call.parameters["plrId"])
                     val reg = call.receive<Registration.Details>()
-                    if (plrId == userSession.playerId) {
+
+                    val current = core.eventCalendar.getPlayerRegistration(evtId, plrId)
+                    val isKickByDm = reg.dungeonMasterId == null && current?.details?.dungeonMasterId == userSession.playerId
+                    val isInviteByDm = reg.dungeonMasterId == userSession.playerId && current?.details?.dungeonMasterId == null
+
+                    if (plrId == userSession.playerId || isKickByDm || isInviteByDm) {
                         core.eventCalendar.updatePlayerRegistration(evtId, plrId, reg)
                         call.respond(HttpStatusCode.OK)
                     } else {
-                        call.respond(HttpStatusCode.Forbidden, "You can only edit your own registration")
+                        call.respond(HttpStatusCode.Forbidden, "Only you or your DM cam edit your registration")
                     }
                 }
             }

--- a/src/jvmMain/kotlin/org/codecranachan/roster/core/CalendarLogic.kt
+++ b/src/jvmMain/kotlin/org/codecranachan/roster/core/CalendarLogic.kt
@@ -70,6 +70,10 @@ class EventCalendarLogic(
         eventBus.publish(CalendarEventUpdated(previous!!, current!!))
     }
 
+    fun getPlayerRegistration(eventId: Uuid, playerId: Uuid): Registration? {
+        return eventRepository.getRegistration(eventId, playerId)
+    }
+
     /**
      * Registers a player for a given event.
      */

--- a/src/jvmMain/resources/themes/event.cmsg
+++ b/src/jvmMain/resources/themes/event.cmsg
@@ -6,7 +6,7 @@ To register you can use the buttons on this message or head over to {$root_url}.
 
 -- Table lineup ---
 {% loop in $tables as $tbl %}
-- {$tbl.dungeon_master.discord_mention} is hosting **{$tbl.table.details.adventure_title:Mystery Adventure}** ({$tbl.occupancy_fraction} players)
+- {$tbl.dungeon_master.discord_mention} is hosting **{$tbl.table.details.adventure_title:Mystery Adventure}** ({$tbl.table.details.language.flag} {$tbl.occupancy_fraction} players)
 {% onEmpty %}
 No dungeon masters have signed up
 {% endloop %}
@@ -14,7 +14,7 @@ No dungeon masters have signed up
 --- We have **{$player_count}** players attending and enough tables for **{$table_space}** ---
 **Unseated players**
 {% loop in $unseated as $ust %}
-- {$ust.discord_mention}
+- {$ust.discord_mention} {% loop in $ust.details.languages as $lng divider=" " %}{$lng.flag}{% endloop %}
 {% onEmpty %}
 All players are seated
 {% endloop %}

--- a/src/jvmMain/resources/themes/table.cmsg
+++ b/src/jvmMain/resources/themes/table.cmsg
@@ -11,7 +11,7 @@ Join this table using the button below. If you already joined another table you 
 
 **Seated players**
 {% loop in $players as $plr %}
-- {$plr.discord_mention}
+- {$plr.discord_mention} {% loop in $plr.details.languages as $lng divider=" " %}{$lng.flag}{% endloop %}
 {% onEmpty %}
 No players are sitting at this table
 {% endloop %}


### PR DESCRIPTION
Allows dungeon masters to invite players to their table and kick players from their tables.
Reduces the obnoxiousness of fiddling with player levels and player limits on mobile.
Add language tags to player listings on discord.